### PR TITLE
NAT-640 Workaround for date null pointer exception

### DIFF
--- a/android/src/main/java/com/henninghall/date_picker/State.java
+++ b/android/src/main/java/com/henninghall/date_picker/State.java
@@ -137,7 +137,11 @@ public class State {
     }
 
     private Calendar getDate() {
-        return Utils.isoToCalendar(getIsoDate(), getTimeZone());
+        Calendar calendar = Utils.isoToCalendar(getIsoDate(), getTimeZone());
+        if (calendar == null) { // default fallback to minDate prop
+            calendar = getMinimumDate();
+        }
+        return calendar;
     }
 
     // The date the picker is suppose to display.


### PR DESCRIPTION
NAT-640 Workaround for date null pointer exception
When date format passed from JS fails with parse exception just return a default (minDate prop) to prevent app crashing.